### PR TITLE
More date formatters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ erl_crash.dump
 expm
 package.exs
 /_build
+/docs

--- a/lib/chronos.ex
+++ b/lib/chronos.ex
@@ -3,7 +3,7 @@ defmodule Chronos do
   import Chronos.Validation
 
   @doc """
-    Chronos is an Elixir library for working with dates and times. 
+    Chronos is an Elixir library for working with dates and times.
 
     iex(1)> Chronos.today
     {2013, 8, 21}
@@ -22,7 +22,7 @@ defmodule Chronos do
     iex(2)> {2012, 12, 21} |> Chronos.year
     2012
   """
-  def year(date), do: validate(date) |> _extract_seg(:year)
+  def year(date \\ today), do: validate(date) |> _extract_seg(:year)
 
   @doc """
     The month function allows you to extract the month from a date tuple
@@ -33,7 +33,7 @@ defmodule Chronos do
     iex(2)> {2012, 12, 21} |> Chronos.month
     8
   """
-  def month(date), do: validate(date) |> _extract_seg(:month)
+  def month(date \\ today), do: validate(date) |> _extract_seg(:month)
 
   @doc """
     The day function allows you to extract the day from a date tuple
@@ -44,7 +44,24 @@ defmodule Chronos do
     iex(2)> {2012, 12, 21} |> Chronos.day
     21
   """
-  def day(date), do: validate(date) |> _extract_seg(:day)
+  def day(date \\ today), do: validate(date) |> _extract_seg(:day)
+
+  @doc """
+    The yday function allows you to extract the day of the year (1-366) from a
+    date tuple
+
+    iex(1)> Chronos.yday({2013, 8, 21})
+    233
+
+    iex(2)> {2012, 12, 21} |> Chronos.day
+    356
+  """
+  def yday(date \\ today) do
+    yd = validate(date)
+    |> _extract_seg(:year)
+    |> :calendar.date_to_gregorian_days(1,1)
+    :calendar.date_to_gregorian_days(date) - yd + 1
+  end
 
   @doc """
     The yesterday function is based on the current date
@@ -55,7 +72,7 @@ defmodule Chronos do
     or you can pass it a date:
 
     iex(2)> {2012, 12, 21} |> Chronos.yesterday
-    {2012, 12, 20} 
+    {2012, 12, 20}
 
   """
   def yesterday(date \\ :erlang.date), do: calculate_date_for_days(date, -1)
@@ -69,7 +86,7 @@ defmodule Chronos do
     or you can pass it a date:
 
     iex(2)> {2012, 12, 21} |> Chronos.tomorrow
-    {2012, 12, 22} 
+    {2012, 12, 22}
 
   """
   def tomorrow(date \\ :erlang.date), do: calculate_date_for_days(date, 1)
@@ -178,6 +195,8 @@ defmodule Chronos do
       def month(date), do: unquote(__MODULE__).month(date)
 
       def day(date), do: unquote(__MODULE__).day(date)
+
+      def yday(date), do: unquote(__MODULE__).yday(date)
 
       def yesterday(date \\ unquote(date.())) do
         unquote(__MODULE__).yesterday(date)

--- a/lib/chronos/formatter.ex
+++ b/lib/chronos/formatter.ex
@@ -1,17 +1,121 @@
 defmodule Chronos.Formatter do
+  @moduledoc """
+    The Chronos.Formatter module is used to format date/time tuples.
+  """
 
   @short_date "%Y-%m-%d"
 
+  @monthnames [nil, "January", "February", "March", "April", "May", "June",
+                    "July", "August", "September", "October", "November",
+                    "December"]
+
+  @abbr_monthnames [nil, "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug",
+                         "Sep", "Oct", "Nov", "Dec"]
+
   @doc """
+  The `strftime` formats date/time according to the directives in the given
+  format string.
 
-  The Chronos.Formatter module is used to format date tuples
+  Format is a string with directives, where directives is a:
 
+  `%<flags><conversion>`
+
+  Flags:
+
+  * _  use spaces for padding.
+  * 0  use zeros for padding.
+  * ^  upcase the result string.
+
+  Conversions:
+
+  * Date
+
+  * * %Y - Year with century
+
+    ```
+    iex> Chronos.Formatter.strftime({2012, 12, 21}, "%Y")
+    "2012"
+    ```
+
+  * * %C - Century
+
+    ```
+    iex> Chronos.Formatter.strftime({2012, 12, 21}, "%C")
+    "20"
+    ```
+
+  * * %y - Year without century
+
+    ```
+    iex> Chronos.Formatter.strftime({2012, 12, 21}, "%y")
+    "12"
+    ```
+
+  * * %m - Month of the year
+
+    ```
+    iex> Chronos.Formatter.strftime({2012, 12, 21}, "%m")
+    "12"
+
+    iex> Chronos.Formatter.strftime({2012, 1, 21}, "%0m")
+    "01"
+
+    iex> Chronos.Formatter.strftime({2012, 1, 21}, "%_m")
+    " 1"
+    ```
+
+  * * %B - The full month name
+
+    ```
+    iex> Chronos.Formatter.strftime({2012, 12, 21}, "%B")
+    "December"
+
+    iex> Chronos.Formatter.strftime({2012, 1, 21}, "%^B")
+    "JANUARY"
+    ```
+
+  * * %b - The abbreviated month name
+
+    ```
+    iex> Chronos.Formatter.strftime({2012, 12, 21}, "%b")
+    "Dec"
+
+    iex> Chronos.Formatter.strftime({2012, 1, 21}, "%^b")
+    "JAN"
+    ```
+
+  * * %d - Day of the month
+
+    ```
+    iex> Chronos.Formatter.strftime({2012, 12, 1}, "%d")
+    "1"
+
+    iex> Chronos.Formatter.strftime({2012, 1, 1}, "%_d")
+    " 1"
+
+    iex> Chronos.Formatter.strftime({2012, 1, 1}, "%0d")
+    "01"
+    ```
+
+  * * %j - Day of the year (001..366)
+
+    ```
+    iex> Chronos.Formatter.strftime({2012, 2, 1}, "%j")
+    "32"
+
+    iex> Chronos.Formatter.strftime({2012, 1, 1}, "%j")
+    "1"
+    ```
+
+  Examples:
+
+  ```
   iex> Chronos.Formatter.strftime({2012, 12, 21}, "%Y-%m-%d")
   "2012-12-21"
 
   iex> Chronos.Formatter.strftime({2012, 12, 21}, "Presented on %m/%d/%Y")
   "Presented on 12/21/2012"
-
+  ```
   """
   def strftime({ date, time }, f)  do
     call_format({ date, time }, f) |> Enum.join
@@ -21,16 +125,20 @@ defmodule Chronos.Formatter do
     call_format({ date, :erlang.time }, f) |> Enum.join
   end
 
-  def call_format(date, f), do: format(String.split(f, ~r{(%.?)}), date)
+  defp call_format(date, f) do
+    pattern = ~r{(%[0_^]?[YyCmBbhdHMSPpej])}
+    format(String.split(f, pattern), date)
+  end
 
   @doc """
 
-  The to_short_date function applies the default short date format to
+  The `to_short_date` function applies the default short date format to
   a specified date
 
+  ```
   iex> Chronos.Formatter.to_short_date({2012, 12, 21})
   "2012-12-21"
-
+  ```
   """
   def to_short_date(date), do: strftime(date, @short_date)
 
@@ -42,10 +150,37 @@ defmodule Chronos.Formatter do
   end
 
   defp apply_format({{ y, _, _ }, _time}, "%Y"), do: "#{y}"
+  defp apply_format({{ y, _, _ }, _time}, "%C"), do: "#{div(y, 100)}"
   defp apply_format({{ y, _, _ }, _time}, "%y"), do: "#{rem(y, 100)}"
+
   defp apply_format({{ _, m, _ }, _time}, "%m"), do: "#{m}"
+  defp apply_format({{ _, m, _ }, _time}, "%_m") when m < 10, do: " #{m}"
+  defp apply_format({{ _, m, _ }, _time}, "%_m"), do: "#{m}"
+  defp apply_format({{ _, m, _ }, _time}, "%0m") when m < 10, do: "0#{m}"
+  defp apply_format({{ _, m, _ }, _time}, "%0m"), do: "#{m}"
+  defp apply_format({{ _, m, _ }, _time}, "%B"), do: @monthnames |> Enum.at(m)
+
+  defp apply_format({{ _, m, _ }, _time}, "%^B") do
+    @monthnames |> Enum.at(m) |> String.upcase
+  end
+
+  defp apply_format({{ _, m, _ }, _time}, "%b") do
+    @abbr_monthnames |> Enum.at(m)
+  end
+
+  defp apply_format({{ _, m, _ }, _time}, "%^b") do
+    @abbr_monthnames |> Enum.at(m) |> String.upcase
+  end
+
+  defp apply_format({{ _, _, d }, _time}, "%0d") when d < 10, do: "0#{d}"
+  defp apply_format({{ _, _, d }, _time}, "%0d"), do: "#{d}"
+  defp apply_format({{ _, _, d }, _time}, "%_d") when d < 10, do: " #{d}"
+  defp apply_format({{ _, _, d }, _time}, "%_d"), do: "#{d}"
   defp apply_format({{ _, _, d }, _time}, "%d"), do: "#{d}"
 
+  defp apply_format({date, _time}, "%j"), do: "#{Chronos.yday(date)}"
+
+  defp apply_format({ _date, { h, _, _ }}, "%H") when h < 10, do: "0#{h}"
   defp apply_format({ _date, { h, _, _ }}, "%H"), do: "#{h}"
   defp apply_format({ _date, { _, m, _ }}, "%M"), do: "#{m}"
   defp apply_format({ _date, { _, _, s }}, "%S"), do: "#{s}"
@@ -56,5 +191,4 @@ defmodule Chronos.Formatter do
   defp apply_format({ _date, { h, _, _ }}, "%p") when h >= 12, do: "pm"
 
   defp apply_format(_, f), do: f
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,6 +4,6 @@ defmodule Chronos.Mixfile do
   def project do
     [ app: :chronos,
       version: "0.2.0",
-      deps: [] ]
+      deps: [{ :ex_doc, github: "elixir-lang/ex_doc" }] ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,1 @@
+[ "ex_doc": {:git, "git://github.com/elixir-lang/ex_doc.git", "c14203bfca186f68ff178e5ada9af4f5fb37e205", []} ]

--- a/test/chronos/formatter_test.exs
+++ b/test/chronos/formatter_test.exs
@@ -2,6 +2,7 @@ defmodule FormatterTest do
   use ExUnit.Case
 
   @today { 2012, 12, 21 }
+  @new_year { 2012, 1, 1 }
   @now { {2012, 12, 21}, { 13, 31, 45 } }
 
   import Chronos.Formatter
@@ -16,14 +17,30 @@ defmodule FormatterTest do
 
     # Year
     assert strftime(@today, "%Y") == "2012"
+    assert strftime(@today, "%C") == "20"
     assert strftime(@today, "%y") == "12"
 
     # Month
     assert strftime(@today, "%m") == "12"
+    assert strftime(@new_year, "%m") == "1"
+    assert strftime(@today, "%0m") == "12"
+    assert strftime(@new_year, "%0m") == "01"
+    assert strftime(@today, "%_m") == "12"
+    assert strftime(@new_year, "%_m") == " 1"
+    assert strftime(@today, "%B") == "December"
+    assert strftime(@today, "%^B") == "DECEMBER"
+    assert strftime(@new_year, "%b") == "Jan"
+    assert strftime(@new_year, "%^b") == "JAN"
 
     # Day
     assert strftime(@today, "%d") == "21"
-    assert strftime({2012, 12, 1}, "%d") == "1"
+    assert strftime(@new_year, "%0d") == "01"
+    assert strftime(@today, "%_d") == "21"
+    assert strftime(@new_year, "%_d") == " 1"
+    assert strftime(@new_year, "%d") == "1"
+
+    assert strftime(@new_year, "%j") == "1"
+    assert strftime(@today, "%j") == "356"
 
     assert strftime(@today, "Presented on %m/%d/%Y") == "Presented on 12/21/2012"
     assert strftime(@today, "%Y-%m-%d") == "2012-12-21"
@@ -38,6 +55,7 @@ defmodule FormatterTest do
     assert strftime(earlier, "%m/%d/%Y %H:%M:%S %p") == "12/21/2012 11:31:45 am"
 
     assert strftime(@now, "%H") == "13"
+    assert strftime({ {2012, 12, 21}, { 1, 31, 45 } }, "%H") == "01"
     assert strftime(@now, "%M") == "31"
     assert strftime(@now, "%S") == "45"
   end

--- a/test/chronos_test.exs
+++ b/test/chronos_test.exs
@@ -29,6 +29,11 @@ defmodule ChronosTest do
     assert today |> day == _extract_seg(@today, :day)
   end
 
+  test :yday do
+    assert {2012, 1, 1} |> yday == 1
+    assert {2012, 2, 1} |> yday == 32
+  end
+
   test :yesterday do
     assert today |> yesterday == { 2012, 12, 20 }
     assert yesterday == { 2012, 12, 20 }


### PR DESCRIPTION
I added more date formatters, based on http://ruby-doc.org/stdlib-2.1.1/libdoc/date/rdoc/DateTime.html#method-i-strftime
Cause erlang didn't have %-style strftime I'll want to add the rest later if you agree with my proposal to port many of functions from Date, Time, DateTime from Ruby stdlib and ActiveSupport.
