### PR TITLE
padded single digit minutes and seconds with zero; added tests

### DIFF
--- a/lib/chronos/formatter.ex
+++ b/lib/chronos/formatter.ex
@@ -182,7 +182,9 @@ defmodule Chronos.Formatter do
 
   defp apply_format({ _date, { h, _, _ }}, "%H") when h < 10, do: "0#{h}"
   defp apply_format({ _date, { h, _, _ }}, "%H"), do: "#{h}"
+  defp apply_format({ _date, { _, m, _ }}, "%M") when m < 10, do: "0#{m}"
   defp apply_format({ _date, { _, m, _ }}, "%M"), do: "#{m}"
+  defp apply_format({ _date, { _, _, s }}, "%S") when s < 10, do: "0#{s}"
   defp apply_format({ _date, { _, _, s }}, "%S"), do: "#{s}"
 
   defp apply_format({ _date, { h, _, _ }}, "%P") when h < 12, do: "AM"

--- a/test/chronos/formatter_test.exs
+++ b/test/chronos/formatter_test.exs
@@ -63,6 +63,12 @@ defmodule FormatterTest do
     assert strftime({ {2012, 12, 21}, { 1, 31, 45 } }, "%H") == "01"
     assert strftime(@now, "%M") == "31"
     assert strftime(@now, "%S") == "45"
+
+    earlier_still = {{2012, 12, 21}, {1, 2, 3}}
+    assert strftime(earlier_still, "%H") == "01"
+    assert strftime(earlier_still, "%M") == "02"
+    assert strftime(earlier_still, "%S") == "03"
+
   end
 
 end


### PR DESCRIPTION
Hi -- Getting nice use out of chronos, thanks!  I ran into a little difficulty with minutes and seconds not being zero padded when they were < 10 (hours, however, were fine).  Here's a patch to remedy that if you're interested.
