### PR TITLE
Fix CompileError due to default values and multiple clauses

### DIFF
--- a/lib/chronos.ex
+++ b/lib/chronos.ex
@@ -159,28 +159,32 @@ defmodule Chronos do
     iex(2)> Chronos.weeks_from(3)
     {2013, 9, 11}
   """
-  def days_ago(days, date \\ today) when days > 0 do
+  def days_ago(days, date \\ today)
+  def days_ago(days, date) when days > 0 do
     calculate_date_for_days(date, -days)
   end
   def days_ago(_, _) do
     raise ArgumentError, message: "Number of days must be a positive integer"
   end
 
-  def days_from(days, date \\ today) when days > 0 do
+  def days_from(days, date \\ today)
+  def days_from(days, date) when days > 0 do
     calculate_date_for_days(date, days)
   end
   def days_from(_, _) do
     raise ArgumentError, message: "Number of days must be a positive integer"
   end
 
-  def weeks_ago(weeks, date \\ today) when weeks > 0 do
+  def weeks_ago(weeks, date \\ today)
+  def weeks_ago(weeks, date) when weeks > 0 do
     calculate_date_for_weeks(date, -weeks)
   end
   def weeks_ago(_, _) do
     raise ArgumentError, message: "Number of weeks must be a positive integer"
   end
 
-  def weeks_from(weeks, date \\ today) when weeks > 0 do
+  def weeks_from(weeks, date \\ today)
+  def weeks_from(weeks, date) when weeks > 0 do
     calculate_date_for_weeks(date, weeks)
   end
   def weeks_from(_, _) do


### PR DESCRIPTION
On Elixir 0.14.3, compilation fails with the following message:

```
== Compilation error on file lib/chronos.ex ==
** (CompileError) lib/chronos.ex:165: def days_ago/2 has default values
   and multiple clauses, define a function head with the defaults
    (elixir) src/elixir_def.erl:336: :elixir_def.store_each/8
    (elixir) src/elixir_def.erl:107: :elixir_def.store_definition/9
    lib/chronos.ex:165: (module)
    (stdlib) erl_eval.erl:657: :erl_eval.do_apply/6
    (elixir) src/elixir.erl:170: :elixir.erl_eval/3
```

This is due to a change from elixir-lang/elixir#2467
