### PR TITLE
Implement formatter with pattern matching

### DIFF
--- a/test/chronos/formatter_test.exs
+++ b/test/chronos/formatter_test.exs
@@ -14,6 +14,8 @@ defmodule FormatterTest do
   test :strftime_exceptions do
     assert strftime(@today, "Date\n%D") == "Date\n12/21/2012"
     assert strftime(@today, "Date%%D") == "Date%12/21/2012"
+    assert strftime(@today, "Date%n%D") == "Date%n12/21/2012"
+    assert strftime(@today, "Date%0n%%D") == "Date%0n%12/21/2012"
   end
 
   test :strftime_dates do
@@ -69,6 +71,10 @@ defmodule FormatterTest do
     assert strftime(earlier_still, "%M") == "02"
     assert strftime(earlier_still, "%S") == "03"
 
+  end
+
+  test :strftime_compact_letters do
+    assert strftime(@now, "%Y-%0m-%0dT%H:%M:%S.000Z") == "2012-12-21T13:31:45.000Z"
   end
 
 end


### PR DESCRIPTION
While pondering the regular expression required to fix #15, I decided to try to implement the formatter using pattern matching instead. This is the result; the test suite passes (including a new test case for #15), and based on this extremely unscientific benchmark, appears to be faster.

```
$ git checkout master
$ time mix run benchmark.exs # (5 times)
mix run benchmark.exs  3.39s user 0.12s system 102% cpu 3.425 total
mix run benchmark.exs  3.47s user 0.12s system 102% cpu 3.501 total
mix run benchmark.exs  3.37s user 0.12s system 102% cpu 3.397 total
mix run benchmark.exs  3.36s user 0.12s system 102% cpu 3.396 total
mix run benchmark.exs  3.41s user 0.12s system 102% cpu 3.435 total

$ git checkout bkt-pattern-match-formatter
$ time mix run benchmark.exs # (5 times)
mix run benchmark.exs  1.57s user 0.12s system 105% cpu 1.597 total
mix run benchmark.exs  1.58s user 0.13s system 106% cpu 1.612 total
mix run benchmark.exs  1.54s user 0.12s system 105% cpu 1.569 total
mix run benchmark.exs  1.50s user 0.12s system 105% cpu 1.527 total
mix run benchmark.exs  1.55s user 0.17s system 105% cpu 1.627 total
```

Benchmark script:

``` elixir
Enum.each 1..100000, fn(_n) ->
  Chronos.Formatter.strftime({{2012, 12, 21}, {1, 2, 3}}, "%Y-%0m-%0dT%H:%M:%S.000Z")
end
```
