### PR TITLE
Support for strftime(%f) (milliseconds)

### DIFF
--- a/lib/chronos/formatter.ex
+++ b/lib/chronos/formatter.ex
@@ -17,7 +17,7 @@ defmodule Chronos.Formatter do
   @abbr_daynames [nil, "Mon", "Tue", "Wed", "Thru", "Fri", "Sat", "Sun"]
 
   @flags String.to_char_list "0_^"
-  @conversions String.to_char_list "AaDYyCmBbdHMSPpj"
+  @conversions String.to_char_list "AaDYyCmBbdHMSPpjf"
 
   @doc """
   The `strftime` formats date/time according to the directives in the given
@@ -277,6 +277,20 @@ defmodule Chronos.Formatter do
   defp apply_format({ _date, { h, _, _ }}, "%p") when h < 12, do: "am"
   defp apply_format({ _date, { h, _, _ }}, "%P") when h >= 12, do: "PM"
   defp apply_format({ _date, { h, _, _ }}, "%p") when h >= 12, do: "pm"
+
+  defp apply_format({ _date, { h, _, _, _ }}, "%H") when h < 10, do: "0#{h}"
+  defp apply_format({ _date, { h, _, _, _ }}, "%H"), do: "#{h}"
+  defp apply_format({ _date, { _, m, _, _ }}, "%M") when m < 10, do: "0#{m}"
+  defp apply_format({ _date, { _, m, _, _ }}, "%M"), do: "#{m}"
+  defp apply_format({ _date, { _, _, s, _ }}, "%S") when s < 10, do: "0#{s}"
+  defp apply_format({ _date, { _, _, s, _ }}, "%S"), do: "#{s}"
+  defp apply_format({ _date, { _, _, _, f }}, "%f") when f < 10, do: "0#{f}"
+  defp apply_format({ _date, { _, _, _, f }}, "%f"), do: "#{f}"
+
+  defp apply_format({ _date, { h, _, _, _ }}, "%P") when h < 12, do: "AM"
+  defp apply_format({ _date, { h, _, _, _ }}, "%p") when h < 12, do: "am"
+  defp apply_format({ _date, { h, _, _, _ }}, "%P") when h >= 12, do: "PM"
+  defp apply_format({ _date, { h, _, _, _ }}, "%p") when h >= 12, do: "pm"
 
   defp apply_format(_, f), do: f
 end

--- a/test/chronos/formatter_test.exs
+++ b/test/chronos/formatter_test.exs
@@ -4,6 +4,7 @@ defmodule FormatterTest do
   @today { 2012, 12, 21 }
   @new_year { 2012, 1, 1 }
   @now { {2012, 12, 21}, { 13, 31, 45 } }
+  @now_with_ms { {2012, 12, 21}, { 13, 31, 45, 12223 } }
 
   import Chronos.Formatter
 
@@ -70,6 +71,16 @@ defmodule FormatterTest do
     assert strftime(earlier_still, "%H") == "01"
     assert strftime(earlier_still, "%M") == "02"
     assert strftime(earlier_still, "%S") == "03"
+  end
+
+  test :strftime_date_times_with_ms do
+    assert strftime(@now_with_ms, "%m/%d/%Y %H:%M:%S %P") == "12/21/2012 13:31:45 PM"
+    assert strftime(@now_with_ms, "%m/%d/%Y %H:%M:%S %p") == "12/21/2012 13:31:45 pm"
+
+    assert strftime(@now_with_ms, "%H") == "13"
+    assert strftime(@now_with_ms, "%M") == "31"
+    assert strftime(@now_with_ms, "%S") == "45"
+    assert strftime(@now_with_ms, "%f") == "12223"
   end
 
   test :httpdate do


### PR DESCRIPTION
Ecto returns milliseconds on its timestamps so
if you'd want to use Chronos with it you need
this in order for both to be compatible.