### PR TITLE
Error with beginning_of_week when date is already start of the week.

### DIFF
--- a/lib/chronos.ex
+++ b/lib/chronos.ex
@@ -213,35 +213,35 @@ defmodule Chronos do
     {2013, 9, 11}
   """
   def days_ago(days, date \\ today)
-  def days_ago(days, date) when days > 0 do
+  def days_ago(days, date) when days >= 0 do
     calculate_date_for_days(date, -days)
   end
   def days_ago(days, _) when days < 0 do
-    raise ArgumentError, message: "Number of days must be a positive integer"
+    raise ArgumentError, message: "Number of days must be zero or greater"
   end
 
   def days_from(days, date \\ today)
-  def days_from(days, date) when days > 0 do
+  def days_from(days, date) when days >= 0 do
     calculate_date_for_days(date, days)
   end
   def days_from(_, _) do
-    raise ArgumentError, message: "Number of days must be a positive integer"
+    raise ArgumentError, message: "Number of days must be zero or greater"
   end
 
   def weeks_ago(weeks, date \\ today)
-  def weeks_ago(weeks, date) when weeks > 0 do
+  def weeks_ago(weeks, date) when weeks >= 0 do
     calculate_date_for_weeks(date, -weeks)
   end
   def weeks_ago(_, _) do
-    raise ArgumentError, message: "Number of weeks must be a positive integer"
+    raise ArgumentError, message: "Number of weeks must be zero or greater"
   end
 
   def weeks_from(weeks, date \\ today)
-  def weeks_from(weeks, date) when weeks > 0 do
+  def weeks_from(weeks, date) when weeks >= 0 do
     calculate_date_for_weeks(date, weeks)
   end
   def weeks_from(_, _) do
-    raise ArgumentError, message: "Number of weeks must be a positive integer"
+    raise ArgumentError, message: "Number of weeks must be zero or greater"
   end
 
   defp calculate_date_for_days(date, days) do

--- a/test/chronos_test.exs
+++ b/test/chronos_test.exs
@@ -92,11 +92,12 @@ defmodule ChronosTest do
   test :days_ago do
     assert 10 |> days_ago == { 2012, 12, 11 }
     assert 3 |> days_ago({ 2013, 1, 1 }) == { 2012, 12, 29 }
+    assert 0 |> days_ago == { 2012, 12, 21 }
 
-    assert_raise ArgumentError, "Number of days must be a positive integer", fn ->
+    assert_raise ArgumentError, "Number of days must be zero or greater", fn ->
       days_ago(-3, @today)
     end
-    assert_raise ArgumentError, "Number of days must be a positive integer", fn ->
+    assert_raise ArgumentError, "Number of days must be zero or greater", fn ->
       days_ago(-2)
     end
   end
@@ -104,18 +105,20 @@ defmodule ChronosTest do
   test :days_from do
     assert 10 |> days_from(@today) == { 2012, 12, 31 }
     assert 11 |> days_from(@today) == { 2013, 1, 1 }
+    assert 0 |> days_from(@today) == { 2012, 12, 21 }
 
-    assert_raise ArgumentError, "Number of days must be a positive integer", fn ->
+    assert_raise ArgumentError, "Number of days must be zero or greater", fn ->
       days_from(-3, @today)
     end
   end
 
   test :weeks_ago do
     assert 1 |> weeks_ago == { 2012, 12, 14 }
+    assert 0 |> weeks_ago == { 2012, 12, 21 }
     assert 2 |> weeks_ago == { 2012, 12, 7 }
     assert 1 |> weeks_ago({ 2013, 1, 1 }) == { 2012, 12, 25 }
 
-    assert_raise ArgumentError, "Number of weeks must be a positive integer", fn ->
+    assert_raise ArgumentError, "Number of weeks must be zero or greater", fn ->
       weeks_ago(-3, @today)
     end
   end
@@ -123,8 +126,9 @@ defmodule ChronosTest do
   test :weeks_from do
     assert 1 |> weeks_from == { 2012, 12, 28 }
     assert 2 |> weeks_from == { 2013, 1, 4 }
+    assert 0 |> weeks_from == { 2012, 12, 21 }
 
-    assert_raise ArgumentError, "Number of weeks must be a positive integer", fn ->
+    assert_raise ArgumentError, "Number of weeks must be zero or greater", fn ->
       weeks_from(-3, @today)
     end
   end
@@ -132,6 +136,7 @@ defmodule ChronosTest do
   test :beginning_of_week do
     assert beginning_of_week(@today) == {2012,12,17}
     assert beginning_of_week({2015,1,20}) == {2015,1,19}
+    assert beginning_of_week({2015,1,19}) == {2015,1,19}
     assert beginning_of_week({2015,1,20},3) == {2015,1,14}
   end
   test :end_of_week do


### PR DESCRIPTION
When passing a date tuple to beginning_of_week, that is the actual beginning of the week, the function returns an error rather than returning the date back. For example:

```
iex(10)> Chronos.beginning_of_week({2015, 6, 15})
** (FunctionClauseError) no function clause matching in Chronos.days_ago/2
    lib/chronos.ex:216: Chronos.days_ago(0, {2015, 6, 15})
```

I have updated the functions days_ago, days_from, weeks_ago and weeks_from to handle the case where the offset is zero. Also changed the error message when a negative offset is supplied. 

Updated test cases for these changes. 

