### PR TITLE
Fix piping into unary operator warning.

### DIFF
--- a/lib/chronos.ex
+++ b/lib/chronos.ex
@@ -34,7 +34,7 @@ defmodule Chronos do
   """ 
   def from_epoch_time(timestamp) do
     timestamp 
-     |> +(datetime_to_seconds(@datetime1970))
+     |> Kernel.+(datetime_to_seconds(@datetime1970))
      |> :calendar.gregorian_seconds_to_datetime
   end
 


### PR DESCRIPTION
I am getting a warning in Elixir 1.3:
`warning: piping into a unary operator is deprecated. You could use e.g. Kernel.+(5) instead of +5
  lib/chronos.ex:38`  

This fix should remove the warning.