### PR TITLE
Fix clause that cannot match warning

### DIFF
--- a/lib/chronos/formatter.ex
+++ b/lib/chronos/formatter.ex
@@ -237,10 +237,6 @@ defmodule Chronos.Formatter do
   defp apply_format({{ _, m, _ }, _time}, "%0m"), do: "#{m}"
   defp apply_format({{ _, m, _ }, _time}, "%B"), do: @monthnames |> Enum.at(m)
 
-  defp apply_format({{_, m, _}, _time}, "%B") do
-    @monthnames |> Enum.at(m)
-  end
-
   defp apply_format(date, "%^B") do
     apply_format(date, "%B") |> String.upcase
   end


### PR DESCRIPTION
`apply_format` on line:240 will never match because it is duplicated on line:238
